### PR TITLE
feat: add bootstrap skills, metadata, and licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Intelligent Code Agents Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,41 @@
 # Intelligent Code Agents Skills
 
-This repository is the standalone skills source for ICA.
+This repository is a standalone skills catalog for coding agents.
+It works with ICA, and it can also be used without ICA.
+
+## Agent Bootstrap Prompt
+
+Use this prompt as the first message in a local coding agent:
+
+```text
+Bootstrap ICA for this local environment.
+
+Your task:
+1) Download and install this skill file into your own native skill storage (using your runtime's normal skill conventions):
+   https://raw.githubusercontent.com/intelligentcode-ai/skills/master/skills/ica-bootstrap/SKILL.md
+2) Immediately execute the installed `ica-bootstrap` skill.
+3) Let `ica-bootstrap` complete end-to-end setup, including:
+   - ICA CLI installation
+   - skills source registration/refresh
+   - installation of `ica-cli`
+   - verification (`ica doctor`, `ica list`)
+
+Behavior requirements:
+- Do the work directly on this machine.
+- Do not ask me where skill folders are.
+- Do not ask me to confirm routine steps.
+- Ask only if credentials, permissions, or security policy block execution.
+- If a command fails, diagnose and retry with the safest fallback automatically.
+
+Final output:
+- What you installed
+- What you executed
+- Current ICA health/status
+- Exact blocker only if setup is still not complete
+```
+
+Canonical prompt source:
+- `skills/ica-bootstrap/assets/INITIAL_PROMPT.md`
 
 ## Layout
 
@@ -23,16 +58,120 @@ Each `SKILL.md` should include frontmatter:
 name: <skill-name>
 description: <short behavior summary>
 category: <role|command|process|enforcement|meta>
-version: <optional version string>
+scope: <optional broad domain>
+subcategory: <optional narrow grouping>
+tags:
+  - <optional tag>
+  - <optional tag>
+version: <version string>
+author: <author name>
+contact-email: <maintainer email>
+website: <optional website url>
 ---
 ```
 
 Notes:
-- `category` is recommended so catalog grouping is stable.
+- `category` is required so catalog grouping is stable.
 - If `category` is omitted, ICA falls back to name-based inference and then defaults to `process`.
-- `version` is optional but recommended for ICA-provided skills.
+- `version` is required for contributed skills.
+- `author` and `contact-email` are required for contributed skills.
+- `website` is optional.
+- `scope`, `subcategory`, and `tags` are optional but strongly recommended for filtering/grouping in UIs.
+
+## Metadata for Filtering
+
+Use these fields to support broader, non-development catalogs and better UI filtering:
+
+- `scope`: broad domain
+  - examples: `development`, `system-management`, `social-media`, `operations`, `marketing`
+- `category`: primary classification within a scope
+  - examples: `command`, `process`, `role`, `enforcement`, `meta`
+- `subcategory`: optional finer grouping
+  - examples: `installation`, `release`, `monitoring`, `publishing`
+- `tags`: optional free-form keywords
+  - examples: `onboarding`, `tdd`, `ci`, `security`
+
+Suggested convention:
+- Keep `scope`, `category`, and `subcategory` lowercase with hyphens.
+- Keep tags short, lowercase, and stable over time.
+
+## Root Skill Index (Performance)
+
+This repository may include a root `skills.index.json` file to accelerate catalog loading.
+
+- Purpose: avoid parsing every `SKILL.md` on each catalog refresh.
+- Source of truth: `skills/*/SKILL.md` files.
+- Index role: derived cache for fast discovery/filtering.
+- Expected shape:
+  - top-level: `version`, `generatedAt`, `skills[]`
+  - per skill: `name`, `description`, `category`, optional `scope`, `subcategory`, `tags`, `version`, `author`, `contactEmail`, `website`
+
+If index entries and `SKILL.md` differ, maintainers may regenerate the index during review.
+
+## How to Contribute
+
+Contributions are welcome through pull requests.
+
+Contribution policy:
+
+- Submit **custom skills only** via PR.
+- Each PR is reviewed and may be:
+  - accepted and merged
+  - dismissed/rejected with feedback
+- Keep each PR focused (prefer one skill per PR).
+- Contributions must be compatible with this repository's MIT license.
+- Contributions that require a different or additional license are not accepted.
+
+Required structure:
+
+- Add skills under `skills/<skill-name>/SKILL.md`
+- Use lowercase, hyphenated folder and skill names
+- Include frontmatter aligned with the enhanced ICA spec:
+  - `name` (required)
+  - `description` (required)
+  - `category` (required)
+  - `scope` (optional, recommended)
+  - `subcategory` (optional)
+  - `tags` (optional)
+  - `version` (required)
+  - `author` (required)
+  - `contact-email` (required)
+  - `website` (optional)
+
+Recommended additions:
+
+- `skills/<skill-name>/assets/` for prompt snippets or examples
+- `skills/<skill-name>/references/` for optional deep documentation
+- `skills/<skill-name>/scripts/` for deterministic helper scripts
+
+PR checklist:
+
+- [ ] Skill is custom and self-contained
+- [ ] File path follows `skills/<skill-name>/SKILL.md`
+- [ ] Frontmatter includes `name`, `description`, `category`, `version`, `author`, `contact-email` (and optional `website`)
+- [ ] Frontmatter includes meaningful filter metadata (`scope`/`subcategory`/`tags`) when applicable
+- [ ] Trigger language is specific (does not over-trigger)
+- [ ] Instructions are ordered, actionable, and testable
+- [ ] Includes validation checklist and at least one concrete example
+- [ ] Contribution is MIT-compatible and does not introduce conflicting license terms
+
+By submitting a contribution, you confirm that:
+
+- you have the right to contribute the content
+- you license your contribution under this repository's MIT license
+- you are not adding code/content with conflicting license restrictions
 
 ## Notes
 
-- This repo is consumed by ICA as a source repository.
+- ICA can consume this repo as a skill source, but ICA is not required to use these skills.
 - If embedding another repository inside this repository, use the correct Git term: **submodule**.
+
+## License and Warranty Disclaimer
+
+This repository is licensed under the MIT License. See `LICENSE`.
+
+All skills and related assets are provided **"AS IS"**, without warranties of any kind, express or implied, including merchantability, fitness for a particular purpose, and noninfringement.
+
+No additional grants are provided beyond the MIT license terms, including no service, support, maintenance, certification, indemnity, or trademark grants.
+
+To the maximum extent permitted by law, authors and contributors are not liable for any claim, damages, or other liability arising from, out of, or in connection with the skills or their use.

--- a/skills.index.json
+++ b/skills.index.json
@@ -1,0 +1,367 @@
+{
+  "version": "1",
+  "generatedAt": "2026-02-14T06:34:39.278Z",
+  "skills": [
+    {
+      "name": "agent-browser",
+      "description": "Use when you need to reproduce or debug web UI flows (especially auth/OIDC) via the Agent Browser CLI, capture snapshots/screenshots, and extract redirect URLs and on-page errors deterministically. Includes install/setup guidance when the CLI is missing.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "ai-engineer",
+      "description": "Activate when user needs AI/ML work - model integration, behavioral frameworks, intelligent automation. Activate when the ai-engineer skill is requested or work involves machine learning, agentic systems, or AI-driven features.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "architect",
+      "description": "Activate when user needs architectural decisions, system design, technology selection, or design reviews. Activate when the architect skill is requested or work requires structural decisions. Provides design patterns and architectural guidance.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "autonomy",
+      "description": "Activate when a subagent completes work and needs continuation check. Activate when a task finishes to determine next steps or when detecting work patterns in user messages. Governs automatic work continuation and queue management.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "backend-tester",
+      "description": "Activate when user needs API or backend testing - REST/GraphQL validation, integration tests, database verification. Activate when the backend-tester skill is requested or work requires backend quality assurance.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "best-practices",
+      "description": "Activate when starting new work to check for established patterns. Activate when ensuring consistency with team standards or when promoting successful memory patterns. Searches and applies best practices before implementation.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "branch-protection",
+      "description": "Activate when performing git operations. MANDATORY by default - prevents direct commits to main/master, blocks destructive operations (force push, reset --hard). Enforces dev-first workflow where all changes go to dev before main. Assumes branch protection enabled unless disabled in settings.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "commit-pr",
+      "description": "Activate when user asks to commit, push changes, create a PR, open a pull request, or submit changes for review. Activate when process skill reaches commit or PR phase. Provides commit message formatting and PR structure. PRs default to dev branch, not main. Works with git-privacy skill.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "database-engineer",
+      "description": "Activate when user needs database work - schema design, query optimization, migrations, data modeling. Activate when the database-engineer skill is requested or work involves database design or performance tuning.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "developer",
+      "description": "Activate when user asks to code, build, implement, create, fix bugs, refactor, or write software. Activate when the developer skill is requested. Provides implementation patterns and coding standards for hands-on development work.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "devops-engineer",
+      "description": "Activate when user needs CI/CD or deployment work - pipeline design, deployment automation, release management. Activate when the devops-engineer skill is requested or work involves build systems or infrastructure automation.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "file-placement",
+      "description": "Activate when creating any summary, report, or output file. Ensures files go to correct directories (summaries/, memory/, stories/, bugs/). Mirrors what summary-file-enforcement hook enforces.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "git-privacy",
+      "description": "Activate when performing git commits, creating pull requests, or any git operation. MANDATORY by default - prevents AI attribution (Co-Authored-By, \"Generated with\" footers). Does NOT block legitimate AI feature descriptions.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "ica-bootstrap",
+      "description": "Activate when users need first-time ICA setup from scratch: install ICA CLI, configure sources, install baseline skills (including `ica-cli`), verify health, and hand off to day-2 CLI usage.",
+      "category": "command",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "ica-cli",
+      "description": "Activate when users ask how to use, configure, verify, upgrade, or troubleshoot the ICA CLI (`ica`) after initial setup, including source management and day-2 operations.",
+      "category": "command",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "ica-get-setting",
+      "description": "Activate when needing configuration values like git.privacy, autonomy.level, paths.*, team.default_reviewer. Retrieves ICA settings using dot notation from config hierarchy.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "ica-version",
+      "description": "Activate when user asks about version, system status, \"what version\", or wants to verify ICA installation. Displays version, component status, and installation info.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "infrastructure-protection",
+      "description": "Activate when performing infrastructure, VM, container, or cloud operations. Ensures safety protocols are followed and blocks destructive operations by default. Mirrors agent-infrastructure-protection hook.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "mcp-client",
+      "description": "Universal MCP client for connecting to MCP servers with progressive disclosure. Use when you need to list MCP servers/tools or call an MCP tool against a server that is not already wired into the current agent runtime.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "mcp-common",
+      "description": "Internal shared helpers for ICA MCP tooling (client/proxy). Not intended to be invoked directly by users.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "mcp-config",
+      "description": "Activate when setting up MCP servers, resolving MCP tool availability, or configuring fallbacks for MCP-dependent features. Configures and troubleshoots MCP (Model Context Protocol) integrations.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "mcp-proxy",
+      "description": "Local stdio MCP proxy server that mirrors upstream MCP servers/tools and centralizes authentication (OAuth, headers/env). Register one server in your agent runtime, manage upstreams via .mcp.json and/or $ICA_HOME/mcp-servers.json.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "memory",
+      "description": "Activate when user wants to save knowledge, search past decisions, or manage persistent memories. Handles architecture patterns, implementation logic, issues/fixes, and past implementations. Uses local SQLite + FTS5 + vector embeddings for fast hybrid search. Supports write, search, update, archive, and list operations.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "parallel-execution",
+      "description": "Activate when multiple independent work items can execute concurrently. Activate when coordinating non-blocking task patterns in L3 autonomy mode. Manages parallel execution from .agent/queue/.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "pm",
+      "description": "Activate when user needs coordination, story breakdown, task delegation, or progress tracking. Activate when the pm skill is requested or work requires planning before implementation. PM coordinates specialists but does not implement.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "pr-automerge",
+      "description": "Activate when asked to auto-review and merge a PR. Runs a closed-loop workflow: subagent Stage 3 review -> fix findings -> re-review -> post ICA-REVIEW receipt -> merge (optional via workflow.auto_merge).",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "pr-comments",
+      "description": "Ensures pull request descriptions and commit messages are written for human reviewers — clear, professional, and without any AI attribution. This skill is automatically applied when creating PRs or commits. Use when the user says \"review my PR description\", \"improve PR description\", or \"check commit message\".",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "process",
+      "description": "Activate when user explicitly requests the development workflow process, asks about workflow phases, or says \"start work\", \"begin development\", \"follow the process\". Activate when creating PRs or deploying to production. NOT for simple questions or minor fixes. Enforces TDD by default for implementation work and executes AUTONOMOUSLY - only pauses when human decision is genuinely required.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "qa-engineer",
+      "description": "Activate when user needs test planning or QA strategy - test frameworks, quality metrics, test automation. Activate when the qa-engineer skill is requested or work requires a comprehensive quality assurance approach.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "release",
+      "description": "Activate when user asks to release, bump version, cut a release, merge to main, or tag a version. Handles version bumping (semver), CHANGELOG updates, PR merging, git tagging, and GitHub release creation.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "requirements-engineer",
+      "description": "Activate when user needs requirements gathering - business analysis, specification development, user stories. Activate when the requirements-engineer skill is requested or work requires bridging business and technical understanding.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "reviewer",
+      "description": "Activate when reviewing code, before committing, after committing, or before merging a PR. Activate when user asks to review, audit, check for security issues, or find regressions. Analyzes code for logic errors, regressions, edge cases, security issues, and test gaps. Fixes findings AUTOMATICALLY. Required at process skill quality gates.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "security-engineer",
+      "description": "Activate when user needs security work - vulnerability assessment, security architecture, compliance audits, penetration testing. Activate when the security-engineer skill is requested or work requires security review.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "skill-creator",
+      "description": "Activate when user wants to create a new skill or update an existing skill. Activate when extending capabilities with specialized knowledge, workflows, or tool integrations. Provides guidance for effective skill design.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "skill-writer",
+      "description": "Activate when users want to create or update an Agent Skill and want a Test-Driven Development approach. Defines a red-green-refactor workflow for SKILL.md authoring, trigger quality, validation, and iterative refinement.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "story-breakdown",
+      "description": "Activate when user presents a large story or epic that needs decomposition. Activate when a task spans multiple components or requires coordination across specialists. Creates work items in .agent/queue/ for execution.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "suggest",
+      "description": "Activate when user asks for improvement suggestions, refactoring ideas, or \"what could be better\". Analyzes code and provides realistic, context-aware proposals. Implements safe improvements AUTOMATICALLY. Separate from reviewer (which finds problems).",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "system-engineer",
+      "description": "Activate when user needs infrastructure or system operations work - system reliability, monitoring, capacity planning. Activate when the system-engineer skill is requested or work involves configuration management or operational excellence.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "tdd",
+      "description": "Activate when user asks for Test-Driven Development, test-first implementation, red-green-refactor, or enforcing tests before code. Use for feature work, bug fixes, and refactors; treat TDD as the default rule unless the user explicitly waives it.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "thinking",
+      "description": "Activate when facing complex problems, multi-step decisions, high-risk changes, complex debugging, or architectural decisions. Activate when careful analysis is needed before taking action. Provides explicit step-by-step validation.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "user-tester",
+      "description": "Activate when user needs E2E or user journey testing - browser automation, Puppeteer/Playwright, cross-browser testing. Activate when the user-tester skill is requested or work requires user flow validation or experience verification.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "validate",
+      "description": "Activate when checking if work meets requirements, verifying completion criteria, validating file placement, or ensuring quality standards. Use before marking work complete to verify success criteria are met.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "web-designer",
+      "description": "Activate when user needs UI/UX design work - interface design, user research, design systems, accessibility. Activate when the web-designer skill is requested or work requires visual design or user experience expertise.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "work-queue",
+      "description": "Activate when user has a large task to break into smaller work items. Activate when user asks about work queue status or what remains to do. Activate when managing sequential or parallel execution. Creates and manages .agent/queue/ for cross-platform work tracking.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    },
+    {
+      "name": "workflow",
+      "description": "Activate when checking workflow step requirements, resolving workflow conflicts, or ensuring proper execution sequence. Applies workflow enforcement patterns and validates compliance.",
+      "version": "10.2.14",
+      "author": "Karsten Samaschke",
+      "contactEmail": "karsten@vanillacore.net",
+      "website": "https://vanillacore.net"
+    }
+  ]
+}

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -2,6 +2,9 @@
 name: agent-browser
 description: Use when you need to reproduce or debug web UI flows (especially auth/OIDC) via the Agent Browser CLI, capture snapshots/screenshots, and extract redirect URLs and on-page errors deterministically. Includes install/setup guidance when the CLI is missing.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Agent Browser (CLI)

--- a/skills/ai-engineer/SKILL.md
+++ b/skills/ai-engineer/SKILL.md
@@ -2,6 +2,9 @@
 name: ai-engineer
 description: Activate when user needs AI/ML work - model integration, behavioral frameworks, intelligent automation. Activate when the ai-engineer skill is requested or work involves machine learning, agentic systems, or AI-driven features.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # AI Engineer Role

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -2,6 +2,9 @@
 name: architect
 description: Activate when user needs architectural decisions, system design, technology selection, or design reviews. Activate when the architect skill is requested or work requires structural decisions. Provides design patterns and architectural guidance.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Architect Role

--- a/skills/autonomy/SKILL.md
+++ b/skills/autonomy/SKILL.md
@@ -2,6 +2,9 @@
 name: autonomy
 description: Activate when a subagent completes work and needs continuation check. Activate when a task finishes to determine next steps or when detecting work patterns in user messages. Governs automatic work continuation and queue management.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Autonomy Skill

--- a/skills/backend-tester/SKILL.md
+++ b/skills/backend-tester/SKILL.md
@@ -2,6 +2,9 @@
 name: backend-tester
 description: Activate when user needs API or backend testing - REST/GraphQL validation, integration tests, database verification. Activate when the backend-tester skill is requested or work requires backend quality assurance.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Backend Tester Role

--- a/skills/best-practices/SKILL.md
+++ b/skills/best-practices/SKILL.md
@@ -2,6 +2,9 @@
 name: best-practices
 description: Activate when starting new work to check for established patterns. Activate when ensuring consistency with team standards or when promoting successful memory patterns. Searches and applies best practices before implementation.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Best Practices Skill

--- a/skills/branch-protection/SKILL.md
+++ b/skills/branch-protection/SKILL.md
@@ -2,6 +2,9 @@
 name: branch-protection
 description: Activate when performing git operations. MANDATORY by default - prevents direct commits to main/master, blocks destructive operations (force push, reset --hard). Enforces dev-first workflow where all changes go to dev before main. Assumes branch protection enabled unless disabled in settings.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Branch Protection Skill

--- a/skills/commit-pr/SKILL.md
+++ b/skills/commit-pr/SKILL.md
@@ -2,6 +2,9 @@
 name: commit-pr
 description: Activate when user asks to commit, push changes, create a PR, open a pull request, or submit changes for review. Activate when process skill reaches commit or PR phase. Provides commit message formatting and PR structure. PRs default to dev branch, not main. Works with git-privacy skill.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Git Commit and Pull Request Skill

--- a/skills/database-engineer/SKILL.md
+++ b/skills/database-engineer/SKILL.md
@@ -2,6 +2,9 @@
 name: database-engineer
 description: Activate when user needs database work - schema design, query optimization, migrations, data modeling. Activate when the database-engineer skill is requested or work involves database design or performance tuning.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Database Engineer Role

--- a/skills/developer/SKILL.md
+++ b/skills/developer/SKILL.md
@@ -2,6 +2,9 @@
 name: developer
 description: Activate when user asks to code, build, implement, create, fix bugs, refactor, or write software. Activate when the developer skill is requested. Provides implementation patterns and coding standards for hands-on development work.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Developer Role

--- a/skills/devops-engineer/SKILL.md
+++ b/skills/devops-engineer/SKILL.md
@@ -2,6 +2,9 @@
 name: devops-engineer
 description: Activate when user needs CI/CD or deployment work - pipeline design, deployment automation, release management. Activate when the devops-engineer skill is requested or work involves build systems or infrastructure automation.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # DevOps Engineer Role

--- a/skills/file-placement/SKILL.md
+++ b/skills/file-placement/SKILL.md
@@ -2,6 +2,9 @@
 name: file-placement
 description: Activate when creating any summary, report, or output file. Ensures files go to correct directories (summaries/, memory/, stories/, bugs/). Mirrors what summary-file-enforcement hook enforces.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # File Placement Skill

--- a/skills/git-privacy/SKILL.md
+++ b/skills/git-privacy/SKILL.md
@@ -2,6 +2,9 @@
 name: git-privacy
 description: Activate when performing git commits, creating pull requests, or any git operation. MANDATORY by default - prevents AI attribution (Co-Authored-By, "Generated with" footers). Does NOT block legitimate AI feature descriptions.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Git Privacy Skill

--- a/skills/ica-bootstrap/SKILL.md
+++ b/skills/ica-bootstrap/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: ica-bootstrap
+description: Activate when users need first-time ICA setup from scratch: install ICA CLI, configure sources, install baseline skills (including `ica-cli`), verify health, and hand off to day-2 CLI usage.
+category: command
+version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
+---
+
+# ICA Bootstrap
+
+Use this skill only for first-time or broken-environment setup. This skill bootstraps ICA so users can then use `ica-cli` for regular operations.
+
+## When to Use
+
+- User says "set up ICA from scratch"
+- User has no working `ica` command
+- User wants a one-shot onboarding flow with minimal technical steps
+- User asks to install ICA + skills for IDE/desktop agent usage
+
+## Do Not Use
+
+- Routine CLI usage questions (use `ica-cli`)
+- Feature development unrelated to ICA installation
+
+## Operating Rules
+
+1. Default to minimal user input and safe automatic retries.
+2. Ask user only when credentials, policy restrictions, or explicit target choices are required.
+3. Prefer verified bootstrap first; use source-build fallback only if needed.
+4. Verify at every phase and stop only on true blockers.
+5. Ensure `ica-cli` is installed as the final handoff skill.
+
+## Workflow
+
+### 1) Detect Platform and Preconditions
+
+Run:
+
+```bash
+uname -s 2>/dev/null || true
+command -v ica || true
+command -v git || true
+command -v curl || true
+command -v node || true
+command -v npm || true
+```
+
+### 2) Install ICA CLI (Verified Bootstrap)
+
+macOS/Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/intelligentcode-ai/intelligent-code-agents/main/scripts/bootstrap/install.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+iwr https://raw.githubusercontent.com/intelligentcode-ai/intelligent-code-agents/main/scripts/bootstrap/install.ps1 -UseBasicParsing | iex
+```
+
+Then run:
+
+```bash
+ica install
+```
+
+If bootstrap is blocked, fallback to local source method:
+
+```bash
+npm ci
+npm run build:quick
+node dist/src/installer-cli/index.js install --yes --targets=codex --scope=user --mode=symlink
+```
+
+### 3) Configure Skills Source
+
+```bash
+ica sources list
+ica sources add --repo-url=https://github.com/intelligentcode-ai/skills.git
+ica sources refresh
+ica catalog
+```
+
+If source already exists, skip add and continue.
+
+### 4) Install Baseline Skills and Targets
+
+Use safe defaults unless user specifies otherwise:
+
+- Targets: `codex`
+- Scope: `user`
+- Mode: `symlink` (fallback to `copy` if symlink fails)
+- Baseline skill: `ica-cli`
+
+Example:
+
+```bash
+ica install --yes --targets=codex --scope=user --mode=symlink --skills=ica-cli
+```
+
+On symlink failure:
+
+```bash
+ica install --yes --targets=codex --scope=user --mode=copy --skills=ica-cli
+```
+
+### 5) Verify and Handoff
+
+```bash
+ica --help | head -n 40
+ica doctor
+ica list
+```
+
+Successful handoff criteria:
+
+- `ica` command works
+- `ica doctor` reports healthy setup or only non-blocking warnings
+- skills source is registered
+- `ica-cli` is installed and available for ongoing use
+
+## Troubleshooting
+
+### `ica` still not found
+
+- Open a new terminal/session and re-check `command -v ica`.
+- Use local entrypoint fallback: `node dist/src/installer-cli/index.js ...`.
+
+### Source auth required
+
+```bash
+ica sources auth --id=<source-id> --token=<pat-or-api-key>
+ica sources refresh --id=<source-id>
+```
+
+### CLI installation partially succeeded
+
+```bash
+ica doctor
+ica sync --yes
+ica list
+```
+
+## Validation Checklist
+
+- [ ] Frontmatter is specific and trigger-oriented for first-time setup
+- [ ] Workflow is deterministic and executable end-to-end
+- [ ] Includes verified bootstrap and local fallback
+- [ ] Installs skills source and baseline `ica-cli` skill
+- [ ] Includes verification and explicit handoff criteria
+- [ ] Includes troubleshooting for common blockers
+
+## Response Contract
+
+When this skill runs, output:
+
+1. Current state (what is already installed)
+2. Commands executed (or exact commands required from user)
+3. Verification status (`ica doctor`, `ica list`)
+4. Handoff status ("ready for `ica-cli`" or exact blocker and fix)

--- a/skills/ica-bootstrap/assets/INITIAL_PROMPT.md
+++ b/skills/ica-bootstrap/assets/INITIAL_PROMPT.md
@@ -1,0 +1,30 @@
+# ICA Stage-1 Bootstrap Prompt (Paste Into IDE/Agent)
+
+Use this prompt as the **first message** in any local agent.
+
+```text
+Bootstrap ICA for this local environment.
+
+Your task:
+1) Download and install this skill file into your own native skill storage (using your runtime's normal skill conventions):
+   https://raw.githubusercontent.com/intelligentcode-ai/skills/master/skills/ica-bootstrap/SKILL.md
+2) Immediately execute the installed `ica-bootstrap` skill.
+3) Let `ica-bootstrap` complete end-to-end setup, including:
+   - ICA CLI installation
+   - skills source registration/refresh
+   - installation of `ica-cli`
+   - verification (`ica doctor`, `ica list`)
+
+Behavior requirements:
+- Do the work directly on this machine.
+- Do not ask me where skill folders are.
+- Do not ask me to confirm routine steps.
+- Ask only if credentials, permissions, or security policy block execution.
+- If a command fails, diagnose and retry with the safest fallback automatically.
+
+Final output:
+- What you installed
+- What you executed
+- Current ICA health/status
+- Exact blocker only if setup is still not complete
+```

--- a/skills/ica-cli/SKILL.md
+++ b/skills/ica-cli/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: ica-cli
+description: Activate when users ask how to use, configure, verify, upgrade, or troubleshoot the ICA CLI (`ica`) after initial setup, including source management and day-2 operations.
+category: command
+version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
+---
+
+# ICA CLI Operator
+
+Use this skill when a user needs practical, command-level help with ICA CLI setup and operations.
+
+## Scope
+
+This is the **post-bootstrap** operations skill.
+For first-time machine setup, use `ica-bootstrap` first, then use `ica-cli` for ongoing operations.
+
+## When to Use
+
+- User asks to install ICA or get `ica` working
+- User asks how to configure targets, scope, modes, or config files
+- User asks to verify installation status
+- User asks to fix ICA CLI errors (`command not found`, config/scope issues, source/auth issues)
+
+## Do Not Use
+
+- Pure architecture/design questions with no CLI execution need
+- General coding requests unrelated to ICA installation/configuration
+
+## Operating Rules
+
+1. Prefer deterministic commands and explicit flags over vague guidance.
+2. Detect current state first, then change only what is necessary.
+3. Use user language in explanations and provide copy/paste blocks.
+4. Include platform-specific commands when needed (macOS/Linux vs Windows PowerShell).
+5. After changes, always verify with `ica doctor` and `ica list` (or equivalent local CLI entrypoint).
+6. For first-time setup requests, hand off to `ica-bootstrap` before continuing here.
+
+## Workflow
+
+### 1) Detect Environment and Current State
+
+Run:
+
+```bash
+command -v ica || true
+ica --help | head -n 40
+ica doctor
+ica list
+```
+
+If `ica` is not on `PATH`, continue with installation paths below.
+
+### 2) Install ICA CLI
+
+#### Recommended: Verified Bootstrap
+
+macOS/Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/intelligentcode-ai/intelligent-code-agents/main/scripts/bootstrap/install.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+iwr https://raw.githubusercontent.com/intelligentcode-ai/intelligent-code-agents/main/scripts/bootstrap/install.ps1 -UseBasicParsing | iex
+```
+
+Then run:
+
+```bash
+ica install
+ica launch --open=true
+```
+
+#### Alternative: Build and Run from Local Source Checkout
+
+```bash
+npm ci
+npm run build:quick
+node dist/src/installer-cli/index.js install --yes --targets=codex --scope=user --mode=symlink
+```
+
+Use this path when developing ICA itself or when bootstrap is not desired.
+
+### 3) Configure Installation Correctly
+
+Common flags:
+
+- `--targets=claude,codex,cursor,gemini,antigravity`
+- `--scope=user|project`
+- `--project-path=/absolute/path` (optional for project scope; defaults to current directory)
+- `--mode=symlink|copy`
+- `--config-file=/path/to/ica.config.json`
+- `--mcp-config=/path/to/mcp.json`
+- `--env-file=/path/to/.env`
+
+Examples:
+
+```bash
+# User-scope install for Codex only
+ica install --yes --targets=codex --scope=user --mode=symlink
+
+# Project-scope install for Claude + Codex
+ica install --yes --targets=claude,codex --scope=project --project-path=/path/to/project --mode=symlink
+
+# Non-interactive install with explicit config
+ica install --yes --targets=codex --scope=user --config-file=/path/to/ica.config.json --mcp-config=/path/to/mcp.json
+```
+
+### 4) Manage Sources (Optional but Common)
+
+```bash
+ica sources list
+ica sources add --repo-url=https://github.com/intelligentcode-ai/skills.git
+ica sources refresh
+ica catalog
+```
+
+If authentication is required:
+
+```bash
+ica sources auth --id=<source-id> --token=<pat-or-api-key>
+```
+
+### 5) Verify and Report
+
+Verification commands:
+
+```bash
+ica --help | head -n 40
+ica doctor
+ica list
+```
+
+Expected outputs to confirm:
+
+- CLI is executable
+- Target homes resolved correctly for selected scope
+- Managed assets are listed without errors
+- Dashboard launches with `ica launch --open=true` when requested
+
+## Troubleshooting
+
+### `ica: command not found`
+
+- Re-run bootstrap install and start a new shell session.
+- If using source checkout, use `node dist/src/installer-cli/index.js ...` directly.
+
+### Invalid or empty targets
+
+- Use supported values only: `claude,codex,cursor,gemini,antigravity`.
+
+### Symlink issues (permissions/policy)
+
+- Retry with copy mode:
+
+```bash
+ica install --yes --targets=codex --scope=user --mode=copy
+```
+
+### Wrong scope or wrong project path
+
+- Re-run `ica install` with explicit `--scope` and `--project-path`.
+
+### Claude integration should be disabled
+
+```bash
+ica install --yes --targets=claude --scope=user --install-claude-integration=false
+```
+
+## Validation Checklist
+
+- [ ] Frontmatter includes `name` and trigger-oriented `description`
+- [ ] Directory name and frontmatter `name` both equal `ica-cli`
+- [ ] Includes clear "When to Use" and "Do Not Use" boundaries
+- [ ] Workflow is ordered and deterministic (detect -> install -> configure -> verify)
+- [ ] Includes at least one concrete command example for install/configuration
+- [ ] Includes troubleshooting guidance for common failures
+- [ ] Includes explicit response contract for outputs
+
+## Response Contract
+
+When this skill is used, return:
+
+1. Current state summary (`installed/not installed`, platform, scope, targets)
+2. Commands executed (or recommended) in order
+3. Verification result from `ica doctor` and `ica list`
+4. Next corrective action if any check fails

--- a/skills/ica-get-setting/SKILL.md
+++ b/skills/ica-get-setting/SKILL.md
@@ -2,6 +2,9 @@
 name: ica-get-setting
 description: Activate when needing configuration values like git.privacy, autonomy.level, paths.*, team.default_reviewer. Retrieves ICA settings using dot notation from config hierarchy.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # ICA Get Setting

--- a/skills/ica-version/SKILL.md
+++ b/skills/ica-version/SKILL.md
@@ -2,6 +2,9 @@
 name: ica-version
 description: Activate when user asks about version, system status, "what version", or wants to verify ICA installation. Displays version, component status, and installation info.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # ICA Version

--- a/skills/infrastructure-protection/SKILL.md
+++ b/skills/infrastructure-protection/SKILL.md
@@ -2,6 +2,9 @@
 name: infrastructure-protection
 description: Activate when performing infrastructure, VM, container, or cloud operations. Ensures safety protocols are followed and blocks destructive operations by default. Mirrors agent-infrastructure-protection hook.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Infrastructure Protection Skill

--- a/skills/mcp-client/SKILL.md
+++ b/skills/mcp-client/SKILL.md
@@ -2,6 +2,9 @@
 name: mcp-client
 description: Universal MCP client for connecting to MCP servers with progressive disclosure. Use when you need to list MCP servers/tools or call an MCP tool against a server that is not already wired into the current agent runtime.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # MCP Client (Universal)

--- a/skills/mcp-common/SKILL.md
+++ b/skills/mcp-common/SKILL.md
@@ -2,6 +2,9 @@
 name: mcp-common
 description: Internal shared helpers for ICA MCP tooling (client/proxy). Not intended to be invoked directly by users.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # MCP Common (Internal)

--- a/skills/mcp-config/SKILL.md
+++ b/skills/mcp-config/SKILL.md
@@ -2,6 +2,9 @@
 name: mcp-config
 description: Activate when setting up MCP servers, resolving MCP tool availability, or configuring fallbacks for MCP-dependent features. Configures and troubleshoots MCP (Model Context Protocol) integrations.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # MCP Configuration Skill

--- a/skills/mcp-proxy/SKILL.md
+++ b/skills/mcp-proxy/SKILL.md
@@ -2,6 +2,9 @@
 name: mcp-proxy
 description: Local stdio MCP proxy server that mirrors upstream MCP servers/tools and centralizes authentication (OAuth, headers/env). Register one server in your agent runtime, manage upstreams via .mcp.json and/or $ICA_HOME/mcp-servers.json.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # MCP Proxy (ICA-Owned)

--- a/skills/memory/SKILL.md
+++ b/skills/memory/SKILL.md
@@ -2,6 +2,9 @@
 name: memory
 description: Activate when user wants to save knowledge, search past decisions, or manage persistent memories. Handles architecture patterns, implementation logic, issues/fixes, and past implementations. Uses local SQLite + FTS5 + vector embeddings for fast hybrid search. Supports write, search, update, archive, and list operations.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Memory Skill

--- a/skills/parallel-execution/SKILL.md
+++ b/skills/parallel-execution/SKILL.md
@@ -2,6 +2,9 @@
 name: parallel-execution
 description: Activate when multiple independent work items can execute concurrently. Activate when coordinating non-blocking task patterns in L3 autonomy mode. Manages parallel execution from .agent/queue/.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Parallel Execution Skill

--- a/skills/pm/SKILL.md
+++ b/skills/pm/SKILL.md
@@ -2,6 +2,9 @@
 name: pm
 description: Activate when user needs coordination, story breakdown, task delegation, or progress tracking. Activate when the pm skill is requested or work requires planning before implementation. PM coordinates specialists but does not implement.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # PM Role

--- a/skills/pr-automerge/SKILL.md
+++ b/skills/pr-automerge/SKILL.md
@@ -2,6 +2,9 @@
 name: pr-automerge
 description: Activate when asked to auto-review and merge a PR. Runs a closed-loop workflow: subagent Stage 3 review -> fix findings -> re-review -> post ICA-REVIEW receipt -> merge (optional via workflow.auto_merge).
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # PR Auto-Review And Merge (Closed Loop)

--- a/skills/pr-comments/SKILL.md
+++ b/skills/pr-comments/SKILL.md
@@ -2,6 +2,9 @@
 name: pr-comments
 description: Ensures pull request descriptions and commit messages are written for human reviewers — clear, professional, and without any AI attribution. This skill is automatically applied when creating PRs or commits. Use when the user says "review my PR description", "improve PR description", or "check commit message".
 user-invocable: false
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # PR & Commit Quality Standards

--- a/skills/process/SKILL.md
+++ b/skills/process/SKILL.md
@@ -2,6 +2,9 @@
 name: process
 description: Activate when user explicitly requests the development workflow process, asks about workflow phases, or says "start work", "begin development", "follow the process". Activate when creating PRs or deploying to production. NOT for simple questions or minor fixes. Enforces TDD by default for implementation work and executes AUTONOMOUSLY - only pauses when human decision is genuinely required.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Development Process

--- a/skills/qa-engineer/SKILL.md
+++ b/skills/qa-engineer/SKILL.md
@@ -2,6 +2,9 @@
 name: qa-engineer
 description: Activate when user needs test planning or QA strategy - test frameworks, quality metrics, test automation. Activate when the qa-engineer skill is requested or work requires a comprehensive quality assurance approach.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # QA Engineer Role

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -2,6 +2,9 @@
 name: release
 description: Activate when user asks to release, bump version, cut a release, merge to main, or tag a version. Handles version bumping (semver), CHANGELOG updates, PR merging, git tagging, and GitHub release creation.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Release Skill

--- a/skills/requirements-engineer/SKILL.md
+++ b/skills/requirements-engineer/SKILL.md
@@ -2,6 +2,9 @@
 name: requirements-engineer
 description: Activate when user needs requirements gathering - business analysis, specification development, user stories. Activate when the requirements-engineer skill is requested or work requires bridging business and technical understanding.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Requirements Engineer Role

--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -2,6 +2,9 @@
 name: reviewer
 description: Activate when reviewing code, before committing, after committing, or before merging a PR. Activate when user asks to review, audit, check for security issues, or find regressions. Analyzes code for logic errors, regressions, edge cases, security issues, and test gaps. Fixes findings AUTOMATICALLY. Required at process skill quality gates.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Reviewer Skill

--- a/skills/security-engineer/SKILL.md
+++ b/skills/security-engineer/SKILL.md
@@ -2,6 +2,9 @@
 name: security-engineer
 description: Activate when user needs security work - vulnerability assessment, security architecture, compliance audits, penetration testing. Activate when the security-engineer skill is requested or work requires security review.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Security Engineer Role

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -3,6 +3,9 @@ name: skill-creator
 description: Activate when user wants to create a new skill or update an existing skill. Activate when extending capabilities with specialized knowledge, workflows, or tool integrations. Provides guidance for effective skill design.
 version: 10.2.14
 license: Complete terms in LICENSE.txt
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Skill Creator

--- a/skills/skill-writer/SKILL.md
+++ b/skills/skill-writer/SKILL.md
@@ -2,6 +2,9 @@
 name: skill-writer
 description: Activate when users want to create or update an Agent Skill and want a Test-Driven Development approach. Defines a red-green-refactor workflow for SKILL.md authoring, trigger quality, validation, and iterative refinement.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Skill Writer

--- a/skills/story-breakdown/SKILL.md
+++ b/skills/story-breakdown/SKILL.md
@@ -2,6 +2,9 @@
 name: story-breakdown
 description: Activate when user presents a large story or epic that needs decomposition. Activate when a task spans multiple components or requires coordination across specialists. Creates work items in .agent/queue/ for execution.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Story Breakdown Skill

--- a/skills/suggest/SKILL.md
+++ b/skills/suggest/SKILL.md
@@ -2,6 +2,9 @@
 name: suggest
 description: Activate when user asks for improvement suggestions, refactoring ideas, or "what could be better". Analyzes code and provides realistic, context-aware proposals. Implements safe improvements AUTOMATICALLY. Separate from reviewer (which finds problems).
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Suggest Skill

--- a/skills/system-engineer/SKILL.md
+++ b/skills/system-engineer/SKILL.md
@@ -2,6 +2,9 @@
 name: system-engineer
 description: Activate when user needs infrastructure or system operations work - system reliability, monitoring, capacity planning. Activate when the system-engineer skill is requested or work involves configuration management or operational excellence.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # System Engineer Role

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -2,6 +2,9 @@
 name: tdd
 description: Activate when user asks for Test-Driven Development, test-first implementation, red-green-refactor, or enforcing tests before code. Use for feature work, bug fixes, and refactors; treat TDD as the default rule unless the user explicitly waives it.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # TDD Skill

--- a/skills/thinking/SKILL.md
+++ b/skills/thinking/SKILL.md
@@ -2,6 +2,9 @@
 name: thinking
 description: Activate when facing complex problems, multi-step decisions, high-risk changes, complex debugging, or architectural decisions. Activate when careful analysis is needed before taking action. Provides explicit step-by-step validation.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Thinking Skill

--- a/skills/user-tester/SKILL.md
+++ b/skills/user-tester/SKILL.md
@@ -2,6 +2,9 @@
 name: user-tester
 description: Activate when user needs E2E or user journey testing - browser automation, Puppeteer/Playwright, cross-browser testing. Activate when the user-tester skill is requested or work requires user flow validation or experience verification.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # User Tester Role

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -2,6 +2,9 @@
 name: validate
 description: Activate when checking if work meets requirements, verifying completion criteria, validating file placement, or ensuring quality standards. Use before marking work complete to verify success criteria are met.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Validation Skill

--- a/skills/web-designer/SKILL.md
+++ b/skills/web-designer/SKILL.md
@@ -2,6 +2,9 @@
 name: web-designer
 description: Activate when user needs UI/UX design work - interface design, user research, design systems, accessibility. Activate when the web-designer skill is requested or work requires visual design or user experience expertise.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Web Designer Role

--- a/skills/work-queue/SKILL.md
+++ b/skills/work-queue/SKILL.md
@@ -2,6 +2,9 @@
 name: work-queue
 description: Activate when user has a large task to break into smaller work items. Activate when user asks about work queue status or what remains to do. Activate when managing sequential or parallel execution. Creates and manages .agent/queue/ for cross-platform work tracking.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Work Queue Skill

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -2,6 +2,9 @@
 name: workflow
 description: Activate when checking workflow step requirements, resolving workflow conflicts, or ensuring proper execution sequence. Applies workflow enforcement patterns and validates compliance.
 version: 10.2.14
+author: "Karsten Samaschke"
+contact-email: "karsten@vanillacore.net"
+website: "https://vanillacore.net"
 ---
 
 # Workflow Skill


### PR DESCRIPTION
## Summary
- add bootstrap-focused onboarding skills for first-time setup and day-2 operations
- establish repository licensing and contribution policy for MIT-only submissions
- add required maintainer metadata to all existing skills and generate root index

## Changes
- added `skills/ica-bootstrap/SKILL.md` and `skills/ica-bootstrap/assets/INITIAL_PROMPT.md`
- added `skills/ica-cli/SKILL.md` for post-bootstrap CLI usage
- added MIT `LICENSE`
- generated root `skills.index.json` for faster catalog discovery
- updated all existing `skills/*/SKILL.md` frontmatter with `author`, `contact-email`, `website`
- updated README with bootstrap prompt, contribution policy, metadata spec, and legal disclaimers

## Test Plan
- [x] `git diff --check`
- [x] repo-wide frontmatter metadata validation for all `skills/*/SKILL.md`
- [x] generated and inspected `skills.index.json`

## Breaking Changes
- None expected for skill loading. Metadata is additive.