### PR TITLE
docs: strengthen README contribution CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # Intelligent Code Agents Skills
 
-This repository is a standalone skills catalog for coding agents.
-It works with ICA, and it can also be used without ICA.
+A practical, portable skills catalog for local coding agents.
+Use it with ICA for managed installs, or use it standalone in your own workflow.
 
-## Agent Bootstrap Prompt
+## Contribute a Skill
 
-Use this prompt as the first message in a local coding agent:
+Contributions happen directly in this repository.
+
+- Submit your custom skill as a pull request: [Create Pull Request](https://github.com/intelligentcode-ai/skills/pulls)
+- Before submitting, follow: [How to Contribute](https://github.com/intelligentcode-ai/skills#how-to-contribute)
+
+## Agent Bootstrap Prompt (Fastest Start)
+
+Paste this into a local coding agent to bootstrap setup quickly:
 
 ```text
 Bootstrap ICA for this local environment.


### PR DESCRIPTION
## Summary
- Strengthen top-level README language for clarity and standalone usage
- Add an explicit contribution call-to-action near the top

## Changes
- Updated intro copy in `README.md`
- Added `Contribute a Skill` section with direct PR and contribution-guide links
- Refined bootstrap section heading and lead-in copy

## Test Plan
- [x] `git diff --check`
- [x] Manual README rendering/flow review
- [ ] No automated test suite in this repository for README-only changes

## Breaking Changes
- None