### PR TITLE
fix: require R/G/R work items only when TDD is performed

### DIFF
--- a/skills/create-work-items/SKILL.md
+++ b/skills/create-work-items/SKILL.md
@@ -47,6 +47,27 @@ Each created item should include:
 
 If fields are missing, ask focused clarification (short, bounded), then proceed.
 
+## TDD Decomposition Rule (MANDATORY)
+
+If TDD is being performed for the requested scope, you MUST create explicit work items for:
+- `RED` - write/update failing test first
+- `GREEN` - implement minimal code to make RED pass
+- `REFACTOR` - cleanup and improve design with tests still green
+
+These are required work items, not optional notes.
+
+Required dependency order:
+- `GREEN` blocked by `RED`
+- `REFACTOR` blocked by `GREEN`
+
+For GitHub backend:
+- create these as separate child issues (typically `type/work-item`)
+- use clear titles like `[RED] ...`, `[GREEN] ...`, `[REFACTOR] ...`
+- create and verify native parent-child links
+
+For file-based backend:
+- create three separate `.agent/queue/` items with explicit phase markers
+
 ## Creation Rules
 
 - GitHub backend:
@@ -63,3 +84,4 @@ Return a concise creation summary:
 - items created (ids/urls or filenames)
 - type/priority
 - parent + native-link verification status (if applicable)
+- TDD phase items created (`RED`/`GREEN`/`REFACTOR`) and dependency wiring status

--- a/skills/github-issues-planning/SKILL.md
+++ b/skills/github-issues-planning/SKILL.md
@@ -90,23 +90,34 @@ Do not use this skill when requests are unrelated to issue planning:
 - MCP fallback path: use GitHub MCP issue creation/update tools with explicit type/priority labels and optional parent marker.
 - Use dry-run and minimal field selection for sensitive repos.
 
-6. Encode parent-child relationship correctly.
+6. Enforce explicit TDD phase work items when applicable.
+- If TDD is being performed for the scoped implementation, create explicit issues for:
+  - `[RED] ...`
+  - `[GREEN] ...`
+  - `[REFACTOR] ...`
+- These MUST be separate work items (usually `type/work-item`) and MUST be executed in order.
+- Link each phase natively to the parent story/feature/bug item, and capture dependency order:
+  - `GREEN` blocked by `RED`
+  - `REFACTOR` blocked by `GREEN`
+
+7. Encode parent-child relationship correctly.
 - Always include `Parent: #<number>` in child issue body when `--parent` is provided for human traceability.
 - Treat body marker as trace text only; it is not a native GitHub relationship.
 - Create native GitHub parent-child relationship via GitHub UI or API workflow supported by your environment.
 - Verify native link exists before reporting hierarchy creation success.
 - For epic parents, you may additionally maintain a child checklist in the epic body.
 
-7. Apply token-usage discipline.
+8. Apply token-usage discipline.
 - Fetch only required fields (avoid large body payloads unless parent parsing is required).
 - Bound retrieval sizes (`per_page`/`limit`) and scope (`state`, labels, assignee) before broad queries.
 - Prefer incremental sync (`since`-style filters) for repeated runs.
 
-8. Return a concise planning summary.
+9. Return a concise planning summary.
 - Confirm requirements status (`gh`, auth, Python launcher, target repo).
 - Report created issue URL/number.
 - Report resolved target repo and why (explicit vs inferred).
 - Report issue type, priority, and parent reference.
+- Report TDD phase issue creation and execution-order wiring status when applicable.
 - Report whether MCP or CLI transport was used and why.
 
 ## MCP Proxy And Tool References
@@ -144,6 +155,8 @@ Detailed examples: `skills/github-issues-planning/references/issue-taxonomy.md`
 - [ ] Issue has one valid priority label
 - [ ] Parent trace marker is present when requested
 - [ ] Native GitHub parent-child relationship is created and verified when requested
+- [ ] Explicit TDD phase issues (`RED`/`GREEN`/`REFACTOR`) exist when TDD applies
+- [ ] TDD phase dependencies enforce `RED -> GREEN -> REFACTOR`
 - [ ] Retrieval/creation scope is bounded for token efficiency
 - [ ] Final response includes issue URL and metadata summary
 

--- a/skills/plan-work-items/SKILL.md
+++ b/skills/plan-work-items/SKILL.md
@@ -22,8 +22,20 @@ Prioritize and structure work items so execution can proceed deterministically.
 1. Load current backlog from active backend.
 2. Normalize item types and priorities.
 3. Build dependency graph (blocks/blocked-by).
-4. Identify actionable next set (unblocked, highest priority).
-5. Publish planning result back to backend.
+4. Enforce TDD phase chain only when TDD is being performed (`RED` -> `GREEN` -> `REFACTOR`).
+5. Identify actionable next set (unblocked, highest priority).
+6. Publish planning result back to backend.
+
+## TDD Planning Gate (MANDATORY)
+
+When TDD is being performed for the scoped work:
+- explicit `RED`, `GREEN`, `REFACTOR` work items MUST exist
+- they MUST be dependency-linked in that order
+- planning is NOT complete until this chain is present and actionable ordering respects it
+
+If the chain is missing:
+- create missing phase items via `create-work-items`
+- re-run planning pass
 
 ## Parent/Child Rule (GitHub)
 
@@ -38,4 +50,5 @@ Return:
 - blocked vs actionable items
 - dependency risks
 - hierarchy verification status
+- TDD phase-chain status (`RED`/`GREEN`/`REFACTOR`)
 - recommended next item(s) for `run-work-items`

--- a/skills/process/SKILL.md
+++ b/skills/process/SKILL.md
@@ -105,6 +105,10 @@ Create or normalize work items as typed units:
 
 If GitHub backend is active:
   - Use github-issues-planning workflow to create typed issues
+
+If TDD is being performed for this scope:
+  - MUST create explicit phase work items: RED, GREEN, REFACTOR
+  - MUST plan them for execution in dependency order
 ```
 
 ### Step 0.3: plan (Priorities + Relationships)
@@ -126,6 +130,7 @@ Proceed to Phase 1 only when:
   - Blockers/dependencies are known
   - Tracking state is current
   - run-work-items has a selected next item
+  - if TDD is being performed: explicit RED/GREEN/REFACTOR items exist and are sequenced
 ```
 
 ## Phase 1: Development (AUTONOMOUS)

--- a/skills/run-work-items/SKILL.md
+++ b/skills/run-work-items/SKILL.md
@@ -20,10 +20,24 @@ Execute the next actionable work item and maintain continuous state tracking.
 ## Execution Workflow
 
 1. Load prioritized plan from active backend.
-2. Select next actionable unblocked item.
-3. Execute with `process` quality gates (`tdd`, test loop, review loop).
-4. Update state continuously (`in_progress`, `blocked`, `completed`).
-5. On completion, re-evaluate next actionable item.
+2. Enforce TDD phase order when applicable (`RED` -> `GREEN` -> `REFACTOR`).
+3. Select next actionable unblocked item.
+4. Execute with `process` quality gates (`tdd`, test loop, review loop).
+5. Update state continuously (`in_progress`, `blocked`, `completed`).
+6. On completion, re-evaluate next actionable item.
+
+## TDD Execution Gate (MANDATORY)
+
+If TDD is being performed for the work scope:
+- you MUST execute explicit `RED`, `GREEN`, `REFACTOR` items in order
+- you MUST NOT skip directly to implementation/refactor without completed prior phase
+
+Phase completion expectations:
+- `RED`: failing test evidence captured for target behavior
+- `GREEN`: minimal implementation passes targeted tests
+- `REFACTOR`: design cleanup completed with tests still passing
+
+If chain items are missing, stop run selection and route back to `create-work-items` + `plan-work-items`.
 
 ## Backend State Updates
 
@@ -42,4 +56,5 @@ Return:
 - item executed
 - result/status change
 - test/review gate summary
+- TDD phase evidence status when applicable
 - next action (continue/blocked/done)


### PR DESCRIPTION
## Summary
- tighten planning policy so explicit `RED` / `GREEN` / `REFACTOR` work items are required **only when TDD is actually being performed**
- remove broader wording that could force phase items when TDD is not in scope
- keep strict phase ordering and execution gates when TDD is in scope

## Changes
- updated:
  - `skills/create-work-items/SKILL.md`
  - `skills/plan-work-items/SKILL.md`
  - `skills/run-work-items/SKILL.md`
  - `skills/github-issues-planning/SKILL.md`
  - `skills/process/SKILL.md`

## Test Plan
- [x] grep validation for "being performed" language across touched skills
- [x] negative check ensuring no leftover "expected/previously used" wording in touched files
- [x] synced to local runtime (`/Users/karsten/.ica/official-skills/skills`) and re-validated

## Breaking Changes
- none